### PR TITLE
チャット履歴を全表示から20件に制限。　スクロールすると追加でチャットが表示されるように修正。

### DIFF
--- a/src/app/Http/Controllers/ChatController.php
+++ b/src/app/Http/Controllers/ChatController.php
@@ -13,7 +13,7 @@ class ChatController extends Controller
     public function index()
     {
         // 最新の15件のメッセージを取得
-        $messages = ChatMessage::orderBy('created_at', 'desc')->take(15)->get();
+        $messages = ChatMessage::orderBy('created_at', 'desc')->take(20)->get();
 
         // メッセージを古い順に並べ替え
         $messages = $messages->sortBy('created_at');
@@ -68,5 +68,20 @@ class ChatController extends Controller
         }
 
         return response()->json(['status' => 'success']);
+    }
+
+    public function loadMore($lastMessageId)
+    {
+        // 最後のメッセージIDより古いメッセージを15件取得
+        $messages = ChatMessage::where('id', '<', $lastMessageId)
+            ->orderBy('created_at', 'desc')
+            ->skip(20)
+            ->take(15)
+            ->get();
+
+        // メッセージを古い順に並べ替え
+        $messages = $messages->sortBy('created_at');
+
+        return response()->json($messages);
     }
 }

--- a/src/database/migrations/2024_12_05_124530_create_read_receipts_table.php
+++ b/src/database/migrations/2024_12_05_124530_create_read_receipts_table.php
@@ -4,26 +4,28 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class CreateReadReceiptsTable extends Migration
 {
     /**
      * Run the migrations.
      */
-    public function up()
+    public function up(): void
     {
-        Schema::create('read_receipts', function (Blueprint $table) {
-            $table->id();
-            $table->foreignId('message_id')->constrained('chat_messages')->onDelete('cascade');
-            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
-            $table->timestamps();
-        });
+        if (!Schema::hasTable('read_receipts')) {
+            Schema::create('read_receipts', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('message_id')->constrained('chat_messages')->onDelete('cascade');
+                $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
+                $table->timestamps();
+            });
+        }
     }
 
     /**
      * Reverse the migrations.
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('read_receipts');
     }
-};
+}

--- a/src/database/migrations/2024_12_19_155959_add_data_to_notifications_table.php
+++ b/src/database/migrations/2024_12_19_155959_add_data_to_notifications_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDataToNotificationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('notifications', function (Blueprint $table) {
+            $table->json('data');
+            $table->timestamp('read_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('notifications', function (Blueprint $table) {
+            $table->dropColumn('data');
+            $table->dropColumn('read_at');
+        });
+    }
+}

--- a/src/database/migrations/2024_12_19_173112_create_chat_messages_table.php
+++ b/src/database/migrations/2024_12_19_173112_create_chat_messages_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateChatMessagesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('chat_messages', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->text('message');
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('chat_messages');
+    }
+}

--- a/src/public/js/chat.js
+++ b/src/public/js/chat.js
@@ -1,0 +1,41 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const messages = document.querySelectorAll('li[data-message-id]');
+    let lastMessageId = messages[messages.length - 1].getAttribute('data-message-id');
+    let loading = false;
+
+    window.addEventListener('scroll', function() {
+        if (window.scrollY === 0 && !loading) {
+            loading = true;
+            fetch(`/chat/load-more/${lastMessageId}`)
+                .then(response => response.json())
+                .then(data => {
+                    console.log('Loaded data:', data); // レスポンスの形式を確認
+                    const chatMessages = document.getElementById('chat-messages');
+                    if (!chatMessages) {
+                        console.error('Element with id "chat-messages" not found.');
+                        return;
+                    }
+                    const messagesArray = Object.values(data); // オブジェクトの値を配列に変換
+                    messagesArray.forEach(message => {
+                        const li = document.createElement('li');
+                        li.setAttribute('data-message-id', message.id);
+                        li.innerHTML = `${message.created_at} - ${message.message}`;
+                        if (Array.isArray(message.read_by) && message.read_by.length > 1) {
+                            const span = document.createElement('span');
+                            span.textContent = `既読${message.read_by.length - 1}`;
+                            li.appendChild(span);
+                        }
+                        chatMessages.insertBefore(li, chatMessages.firstChild);
+                    });
+                    if (messagesArray.length > 0) {
+                        lastMessageId = messagesArray[messagesArray.length - 1].id;
+                    }
+                    loading = false;
+                })
+                .catch(error => {
+                    console.error('Error loading more messages:', error);
+                    loading = false;
+                });
+        }
+    });
+});

--- a/src/resources/views/chat/chat.blade.php
+++ b/src/resources/views/chat/chat.blade.php
@@ -13,7 +13,7 @@
         <input type="text" name="message" placeholder="テキストを入力">
         <button type="submit">送信</button>
     </form>
-    <ul>
+    <ul id="chat-messages">
         @foreach($messages as $message)
             <li data-message-id="{{ $message->id }}">
                 {{ $message->created_at }} - {{ $message->message }}
@@ -24,20 +24,6 @@
         @endforeach
     </ul>
 
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            const messages = document.querySelectorAll('li[data-message-id]');
-            messages.forEach(message => {
-                const messageId = message.getAttribute('data-message-id');
-                fetch(`/chat/read/${messageId}`, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
-                    }
-                });
-            });
-        });
-    </script>
+    <script src="{{ asset('js/chat.js')}}"></script>
 </body>
 </html>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -37,6 +37,10 @@ Route::middleware('auth')->group(function () {
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
 
+Route::get('/chat', [ChatController::class, 'index'])->name('chat.index');
+Route::post('/chat/store', [ChatController::class, 'store'])->name('chat.store');
+Route::get('/chat/load-more/{lastMessageId}', [ChatController::class, 'loadMore'])->name('chat.loadMore');
+
 Route::view('/webpush', 'webpush')->name('webpush.webpush');
 
 Route::post('/set-subscription', [WebPushController::class, 'setSubscription'])


### PR DESCRIPTION
毎回/チャットに遷移する際、mac君のファンがすごい回るので、追加の機能を追加する前に処理を軽くするための処置をとりました。